### PR TITLE
Add sync_options to BucketDeployment

### DIFF
--- a/packages/@aws-cdk/custom-resource-handlers/lib/aws-s3-deployment/bucket-deployment-handler/index.py
+++ b/packages/@aws-cdk/custom-resource-handlers/lib/aws-s3-deployment/bucket-deployment-handler/index.py
@@ -65,6 +65,7 @@ def handler(event, context):
             include             = props.get('Include', [])
             sign_content        = props.get('SignContent', 'false').lower() == 'true'
             output_object_keys  = props.get('OutputObjectKeys', 'true') == 'true'
+            sync_options        = props.get('SyncOptions', [])
 
             # backwards compatibility - if "SourceMarkers" is not specified,
             # assume all sources have an empty market map
@@ -128,7 +129,7 @@ def handler(event, context):
             aws_command("s3", "rm", old_s3_dest, "--recursive")
 
         if request_type == "Update" or request_type == "Create":
-            s3_deploy(s3_source_zips, s3_dest, user_metadata, system_metadata, prune, exclude, include, source_markers, extract)
+            s3_deploy(s3_source_zips, s3_dest, user_metadata, system_metadata, prune, exclude, include, source_markers, extract, sync_options)
 
         if distribution_id:
             cloudfront_invalidate(distribution_id, distribution_paths)
@@ -160,7 +161,7 @@ def sanitize_message(message):
 
 #---------------------------------------------------------------------------------------------------
 # populate all files from s3_source_zips to a destination bucket
-def s3_deploy(s3_source_zips, s3_dest, user_metadata, system_metadata, prune, exclude, include, source_markers, extract):
+def s3_deploy(s3_source_zips, s3_dest, user_metadata, system_metadata, prune, exclude, include, source_markers, extract, sync_options):
     # list lengths are equal
     if len(s3_source_zips) != len(source_markers):
         raise Exception("'source_markers' and 's3_source_zips' must be the same length")
@@ -210,6 +211,7 @@ def s3_deploy(s3_source_zips, s3_dest, user_metadata, system_metadata, prune, ex
           for filter in include:
             s3_command.extend(["--include", filter])
 
+        s3_command.extend(sync_options)
         s3_command.extend([contents_dir, s3_dest])
         s3_command.extend(create_metadata_args(user_metadata, system_metadata))
         aws_command(*s3_command)

--- a/packages/aws-cdk-lib/aws-s3-deployment/lib/bucket-deployment.ts
+++ b/packages/aws-cdk-lib/aws-s3-deployment/lib/bucket-deployment.ts
@@ -1,4 +1,3 @@
-
 import * as fs from 'fs';
 import { kebab as toKebabCase } from 'case';
 import { Construct } from 'constructs';
@@ -282,6 +281,13 @@ export interface BucketDeploymentProps {
    * @default true
    */
   readonly outputObjectKeys?: boolean;
+
+  /**
+   * Additional options to pass to the `aws s3 sync` command.
+   *
+   * @default []
+   */
+  readonly syncOptions?: string[];
 }
 
 /**
@@ -440,6 +446,7 @@ export class BucketDeployment extends Construct {
         DistributionPaths: props.distributionPaths,
         SignContent: props.signContent,
         OutputObjectKeys: props.outputObjectKeys ?? true,
+        SyncOptions: props.syncOptions ?? [],
         // Passing through the ARN sequences dependency on the deployment
         DestinationBucketArn: cdk.Lazy.string({ produce: () => this.requestDestinationArn ? this.destinationBucket.bucketArn : undefined }),
       },

--- a/packages/aws-cdk-lib/aws-s3-deployment/test/bucket-deployment.test.ts
+++ b/packages/aws-cdk-lib/aws-s3-deployment/test/bucket-deployment.test.ts
@@ -1721,3 +1721,21 @@ test('outputObjectKeys default value is true', () => {
     OutputObjectKeys: true,
   });
 });
+
+test('syncOptions are passed correctly to the custom resource', () => {
+  // GIVEN
+  const stack = new cdk.Stack();
+  const bucket = new s3.Bucket(stack, 'Dest');
+
+  // WHEN
+  new s3deploy.BucketDeployment(stack, 'Deploy', {
+    sources: [s3deploy.Source.asset(path.join(__dirname, 'my-website'))],
+    destinationBucket: bucket,
+    syncOptions: ['--size-only'],
+  });
+
+  // THEN
+  Template.fromStack(stack).hasResourceProperties('Custom::CDKBucketDeployment', {
+    SyncOptions: ['--size-only'],
+  });
+});


### PR DESCRIPTION
Add `sync_options` to `BucketDeployment` to pass AWS S3 sync options.

* **BucketDeploymentProps**: Add `sync_options` with a default value of an empty list in `packages/aws-cdk-lib/aws-s3-deployment/lib/bucket-deployment.ts`.
* **BucketDeployment Constructor**: Pass `sync_options` to the custom resource properties.
* **s3_deploy Function**: Add `sync_options` parameter and include it in the S3 sync command in `packages/@aws-cdk/custom-resource-handlers/lib/aws-s3-deployment/bucket-deployment-handler/index.py`.
* **Tests**: Add test cases in `packages/aws-cdk-lib/aws-s3-deployment/test/bucket-deployment.test.ts` to verify that `sync_options` is passed correctly to the custom resource and included in the S3 sync command.

